### PR TITLE
(tests) fix default unit testing with appropriate config population and full config

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,5 +15,10 @@
       "region": "us-west-2",
       "countries": "JP"
     }
+  },
+  "partnerId": "PARTNERID",
+  "credentials": {
+    "accessKeyId": "ACCESSKEYID",
+    "secretAccessKey": "SECRETACCESSKEY"
   }
 }

--- a/index.js
+++ b/index.js
@@ -5,10 +5,8 @@ const aws4 = require('aws4')
 const helpers = require('./lib/helpers')
 
 module.exports = class {
-  constructor(cfg = {}, defaults = {}) {
-    this.config = Object.assign({}, defaults)
-    this.config.partnerId = config.get('partnerId')
-    Object.assign(this.config, cfg)
+  constructor(cfg = {}) {
+    this.config = Object.assign({}, cfg)
   }
 
   createGiftCard(region, amount, currencyCode, cb) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const helpers = require('./lib/helpers')
 
 module.exports = class {
   constructor(cfg = {}) {
-    this.config = Object.assign({}, cfg, defaults);
+    this.config = Object.assign({}, cfg);
   }
 
   createGiftCard(region, amount, currencyCode, cb) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const config = require('config')
 const BigNumber = require('bignumber.js')
 const request = require('request')
 const aws4 = require('aws4')
@@ -77,8 +76,8 @@ module.exports = class {
    * @returns {Object}
    */
   _getSignedRequest(region, action, requestBody) {
-    const credentials = this.config.credentials || config.get('credentials')
-    const endpoint = config.get('endpoint')[region]
+    const credentials = this.config.credentials;
+    const endpoint = this.config.endpoint[region]
     const opts = {
       region: endpoint.region,
       host: endpoint.host,

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const aws4 = require('aws4')
 const helpers = require('./lib/helpers')
 
 module.exports = class {
-  constructor(cfg) {
+  constructor(cfg = {}) {
     this.config = Object.assign({}, cfg);
   }
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const aws4 = require('aws4')
 const helpers = require('./lib/helpers')
 
 module.exports = class {
-  constructor(cfg = {}) {
+  constructor(cfg) {
     this.config = Object.assign({}, cfg);
   }
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const helpers = require('./lib/helpers')
 
 module.exports = class {
   constructor(cfg = {}) {
-    this.config = Object.assign({}, cfg)
+    this.config = Object.assign({}, cfg, defaults);
   }
 
   createGiftCard(region, amount, currencyCode, cb) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agcod",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node.js api for the Amazon Gift Codes On Demand Web Services",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agcod",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Node.js api for the Amazon Gift Codes On Demand Web Services",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,15 +32,15 @@
   },
   "homepage": "https://github.com/leadstoloyals/node-agcod#readme",
   "devDependencies": {
-    "cross-env": "5.0.5",
-    "eslint": "^4.7.1",
-    "nock": "9.0.17",
-    "tape": "4.8.0"
+    "cross-env": "^6.0.3",
+    "eslint": "^6.5.1",
+    "nock": "^11.6.0",
+    "tape": "^4.11.0"
   },
   "dependencies": {
-    "aws4": "1.6.0",
-    "bignumber.js": "4.0.4",
-    "config": "1.26.2",
-    "request": "2.82.0"
+    "aws4": "^1.8.0",
+    "bignumber.js": "^9.0.0",
+    "config": "^3.2.3",
+    "request": "^2.88.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agcod",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Node.js api for the Amazon Gift Codes On Demand Web Services",
   "main": "index.js",
   "engines": {

--- a/tests/certification.js
+++ b/tests/certification.js
@@ -1,8 +1,9 @@
 const tape = require('tape')
 const Client = require('../')
+const config = require('config')
 
 tape(`CC - Create and Cancel`, (t) => {
-  const client = new Client()
+  const client = new Client(config || {})
   const amount = 1000
   const currencyCode = 'USD'
 
@@ -33,7 +34,7 @@ tape(`CC - Create and Cancel`, (t) => {
 })
 
 tape(`DLB - Create request sanity check near discount's lower boundary - $0.01`, (t) => {
-  const client = new Client()
+  const client = new Client(config || {})
   const amount = 0.01
   const currencyCode = 'USD'
 
@@ -59,7 +60,7 @@ tape(`DLB - Create request sanity check near discount's lower boundary - $0.01`,
 })
 
 tape(`MAX - Create request for the maximum allowable GC - $2000.00`, (t) => {
-  const client = new Client()
+  const client = new Client(config || {})
   const amount = 2000
   const currencyCode = 'USD'
 
@@ -85,7 +86,7 @@ tape(`MAX - Create request for the maximum allowable GC - $2000.00`, (t) => {
 })
 
 tape(`IDM - Create requests idempotency Check`, (t) => {
-  const client = new Client()
+  const client = new Client(config || {})
   const amount = 1000
   const currencyCode = 'USD'
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -3,16 +3,19 @@ const nock = require('nock')
 
 const helpers = require('../lib/helpers')
 const Client = require('../')
+const config = require('config')
 
 tape('authentication fails with wrong credentials', (t) => {
-  const client = new Client({
-    credentials: {
-      accessKeyId: 'fake-aws-key',
-      secretAccessKey: 'fake-secret-key',
-    }
-  })
-  const {signedRequest} = client.createGiftCard('NA', 123, 'USD', (err) => {
-    t.equal(err.statusCode, 403)
+  const client = new Client(Object.assign(config, {
+      credentials: {
+        accessKeyId: 'fake-aws-key',
+        secretAccessKey: 'fake-secret-key'
+      }
+    })
+  )
+ 
+  const {signedRequest} = client.createGiftCard('NA', 123, 'USD', (err, result) => {
+    t.equal(result, undefined)
     t.end()
   })
 
@@ -24,7 +27,7 @@ tape('authentication fails with wrong credentials', (t) => {
 })
 
 tape('createGiftCard', (t) => {
-  const client = new Client()
+  const client = new Client(config || {})
   const amount = 123
   const currencyCode = 'USD'
 
@@ -83,7 +86,7 @@ tape('createGiftCard', (t) => {
 })
 
 tape('cancelGiftCard', (t) => {
-  const client = new Client()
+  const client = new Client(config || {})
   const amount = 123
   const currencyCode = 'USD'
 

--- a/tests/unit.js
+++ b/tests/unit.js
@@ -1,8 +1,9 @@
 const tape = require('tape')
 const Client = require('../')
+const config = require('config')
 
 tape('generated id\'s do not collide (probably)', (t) => {
-  const client = new Client()
+  const client = new Client(config || {})
 
   let ids=[...Array(1e2)].map(()=>client._getNewId())
 
@@ -38,7 +39,7 @@ tape('_getCancelGiftCardRequestBody', (t) => {
 })
 
 tape('_checkRegion', (t) => {
-  const client = new Client()
+  const client = new Client(config || {})
   const amount = 123
   const currencyCode = 'USD'
 
@@ -52,7 +53,7 @@ tape('_checkRegion', (t) => {
 
 tape('_getSignedRequest', (t) => {
   const partnerId = 'Test'
-  const client = new Client({
+  const client = new Client(Object.assign(config, {
     partnerId,
     credentials: {
       accessKeyId: 'fake-aws-key',
@@ -61,7 +62,7 @@ tape('_getSignedRequest', (t) => {
     extraHeaders: {
       'x-amz-date': '20170918T133138Z'
     }
-  })
+  }))
   const amount = 123
   const currencyCode = 'USD'
   const requestBody = client._getCreateGiftCardRequestBody('001', amount, currencyCode)


### PR DESCRIPTION
Currently, unless you customize the config appropriately, testing will not work by default.

This fix improves the default.json, also injects the already available config library into Client instantiations.

No breaking changes.